### PR TITLE
ログイン・サインインに成功・失敗した際のメッセージを表示するようにした

### DIFF
--- a/src/Template/Login/index.ctp
+++ b/src/Template/Login/index.ctp
@@ -7,10 +7,12 @@
     <title>login|chat</title>
     <!-- <link rel="stylesheet" href="style.css" /> -->
     <?= $this->Html->css('chat') ?>
+    <?= $this->Html->css('flashmessage') ?>
 </head>
 <body id="login">
-    <div class="box inner"> 
-        <h1>Welcome<br>Variableavalanchezueha</h1>                   
+<?= $this->Flash->render() ?>
+    <div class="box inner">
+        <h1>Welcome<br>Variableavalanchezueha</h1>
         <!-- <form>
             <input type="text" placeholder="name"/>
             <input type="password" placeholder="password"/>

--- a/src/Template/Users/add.ctp
+++ b/src/Template/Users/add.ctp
@@ -7,9 +7,11 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>signup|chat</title>
   <?= $this->Html->css('chat') ?>
+  <?= $this->Html->css('flashmessage') ?>
 </head>
 
 <body id="signup">
+  <?= $this->Flash->render() ?>
   <div class="box inner">
     <h1>Create<br>Variableavalanchezueha account</h1>
 

--- a/webroot/css/flashmessage.css
+++ b/webroot/css/flashmessage.css
@@ -1,0 +1,25 @@
+div.message {
+    text-align: center;
+    cursor: pointer;
+    display: block;
+    font-weight: normal;
+    padding: 0 1.5rem 0 1.5rem;
+    transition: height 300ms ease-out 0s;
+    background-color: #a0d3e8;
+    color: #626262;
+    top: 15px;
+    right: 15px;
+    z-index: 999;
+    overflow: hidden;
+    height: 50px;
+    line-height: 2.5em;
+}
+
+div.message.error {
+    background-color: #C3232D;
+    color: #FFF;
+}
+
+div.message.hidden {
+    height: 0;
+}


### PR DESCRIPTION
#14 
`<?= $this->Flash->render() ?>` を追加しました。
勝手にflashmessage.cssというファイルを作成してしまったので、chat.css内に書いたほうがよければ修正します。