### PR TITLE
メッセージ投稿フォームのデザインをstyle.cssに追加

### DIFF
--- a/design/style.css
+++ b/design/style.css
@@ -80,7 +80,7 @@ form input[type="password"]{
 	height: 50px;
 }
 
-  /* LOG IN*/
+/* LOG IN*/
 #login form input[type="submit"] {
 	background: #a160cd;
 	border: 0;
@@ -117,4 +117,39 @@ form input[type="password"]{
 }
 #signup form input[type="submit"]:hover {
 	background: #16a0aa;
+}
+
+/* ChatMainPage */
+#chat form {
+	display: flex;
+	flex-flow: row nowrap;
+	justify-content: center;
+	align-items: center;
+	max-width: 960px;
+	position: fixed;
+	bottom: 40px;
+	left: 50%;
+	transform: translateX(-50%);
+}
+form input[type="textarea"] {
+	flex: 0 1 528px;
+	height: 50px;
+	margin: 0 4px;
+	padding: 0 16px;
+	background-color: #3b4148;
+	border-radius: 3px;
+	color: #a9a9a9;
+}
+#chat form input[type="submit"] {
+	height: 50px;
+	margin: 0 4px;
+	padding: 0 16px;
+	background: #eee48d;
+	border: 0;
+	border-radius: 3px;
+	color: #263238;
+	transition: background 0.3s ease-in-out;
+}
+#chat form input[type="submit"]:hover {
+	background: #aaa816;
 }


### PR DESCRIPTION
style.cssにメッセージ投稿フォームのデザインを追加しました。
- ログイン・サインインのフォームと基本的に統一したデザインにしています。
- テキストエリアの横幅は、50文字いれてちょうどくらいにしてあります。
- ウィンドウを縮めた場合は、テキストエリアが縮むようにしています。

#20 